### PR TITLE
Fix calc_scaled_x scaling to match Kljun (2015) Eq. 7

### DIFF
--- a/src/fluxfootprints/improved_ffp.py
+++ b/src/fluxfootprints/improved_ffp.py
@@ -522,6 +522,19 @@ class FFPModel(BaseFootprintModel):
         """
         Calculate the scaled distance X* based on wind and height parameters.
 
+        Implements Eq. 7 of Kljun et al. (2015):
+
+        .. math::
+
+            X^* = \\frac{x}{z_m}\\left(1 - \\frac{z_m}{h}\\right)
+                  \\left[\\ln\\frac{z_m}{z_0} - \\psi_M\\right]^{-1}
+
+        i.e. ``X* = x/zm * (1 - zm/h) / Pi_4`` with
+        ``Pi_4 = ln(zm/z0) - psi_M = u(zm)/(u* k)`` (Eqs. 6/7). This is the
+        same scaled<->real conversion used in :meth:`calc_xr_footprint`, so the
+        auxiliary source-area contour helpers stay consistent with the main
+        climatology path.
+
         Parameters
         ----------
         x : float or ndarray
@@ -535,13 +548,13 @@ class FFPModel(BaseFootprintModel):
         # Get mean values
         zm_mean = float(self.ds["zm"].mean())
         h_mean = float(self.ds["h"].mean())
-        u_zm_mean = float(self.ds["umean"].mean())
-        ustar_mean = float(self.ds["ustar"].mean())
+
+        # Pi_4 = ln(zm/z0) - psi_M (Eq. 7); 1/Pi_4 maps real -> scaled distance.
+        # calc_pi_4() returns the full Pi_4 (including the stability correction).
+        pi4_mean = float(self.calc_pi_4().mean())
 
         # Calculate scaling
-        result = (
-            x / zm_mean * (1 - zm_mean / h_mean) * (ustar_mean / (u_zm_mean * self.k))
-        )
+        result = x / zm_mean * (1 - zm_mean / h_mean) / pi4_mean
 
         return result
 

--- a/tests/test_improved_ffp.py
+++ b/tests/test_improved_ffp.py
@@ -155,6 +155,37 @@ def test_calc_scaled_x(valid_df):
     assert result.shape == x.shape
 
 
+def test_calc_scaled_x_matches_theory(valid_df):
+    """
+    ``calc_scaled_x`` must implement Eq. 7 of Kljun et al. (2015), i.e.
+    ``X* = x/zm * (1 - zm/h) / Pi_4`` with ``Pi_4 = ln(zm/z0) - psi_M``.
+
+    Two consequences are checked:
+
+    1. Evaluating it at the analytic real-scale peak ``xmax`` (Eq. 22) must
+       return the scaled peak ``X*max = -c/b + d = 0.87`` — this guards against
+       the historical von-Karman (factor k**2) and missing-psi_M bug.
+    2. It must be the exact inverse of ``scale_to_real_distance`` (Eq. 6/7),
+       keeping the source-area contour helpers consistent with the main
+       climatology path.
+    """
+    # Build a model and evaluate against its own derived quantities.
+    model = FFPModel(valid_df)
+    zm = float(model.ds["zm"].mean())
+    h = float(model.ds["h"].mean())
+    pi4 = float(model.calc_pi_4().mean())
+
+    x_star_max = -model.c / model.b + model.d  # 0.87
+    xmax = x_star_max * zm * (1 - zm / h) ** -1 * pi4
+
+    # (1) real peak -> scaled peak
+    assert model.calc_scaled_x(xmax) == pytest.approx(x_star_max, rel=1e-6)
+
+    # (2) round-trip inverse of scale_to_real_distance
+    back = float(model.scale_to_real_distance(x_star_max).mean())
+    assert back == pytest.approx(xmax, rel=1e-6)
+
+
 def test_calc_crosswind_spread(valid_df):
     model = FFPModel(valid_df)
     x = np.array([10.0, 20.0])


### PR DESCRIPTION
## Summary

A validity review of the improved Kljun et al. (2015) FFP implementation against the source paper (GMD 8, 3695–3713) confirmed the **main climatology path is correct** — footprint output lands upwind in the meteorological *from*-direction (matching wind-rose convention) and reproduces the theory (peak `xmax`: 47.2 m theory vs 48.0 m model, crosswind-symmetric, ~0 mass downwind, coefficients per Eqs. 17/19).

The review surfaced one scaling bug in an auxiliary helper, fixed here.

## The bug

`calc_scaled_x()` computed the scaled distance as `x/zm · (1 − zm/h) · u*/(u(zm)·k)` instead of the correct conversion from Eqs. 6/7:

```
X* = x/zm · (1 − zm/h) / Π₄,    Π₄ = ln(zm/z0) − ψ_M = u(zm)/(u* k)
```

The old form placed the von Kármán constant `k` in the denominator rather than the numerator — an error of factor `k² ≈ 0.16` — and also omitted the `ψ_M` stability correction. This mis-scaled the **auxiliary source-area contour helpers** (`calc_crosswind_spread`, `get_source_area_contour`) relative to the main `calc_xr_footprint` climatology, which already uses `Π₄` correctly. The main climatology output was unaffected.

## The fix

- `src/fluxfootprints/improved_ffp.py` — rewrote `calc_scaled_x` as `X* = x/zm · (1 − zm/h) / Π₄`, consistent with `calc_xr_footprint` and `scale_to_real_distance`.
- `tests/test_improved_ffp.py` — added `test_calc_scaled_x_matches_theory`, asserting `X*max = −c/b + d = 0.87` at the analytic peak and round-trip inverse consistency with `scale_to_real_distance`.

## Testing

All 12 tests in `test_improved_ffp.py` pass, including the new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017TgEKfY7nqCUHPKrMfB6qr)_