### PR TITLE
Support list of distance columns in polar_to_cartesian_dataframe

### DIFF
--- a/src/fluxfootprints/by_row_fetch_tools.py
+++ b/src/fluxfootprints/by_row_fetch_tools.py
@@ -14,9 +14,11 @@ def polar_to_cartesian_dataframe(df, wd_column="WD", dist_column="Dist"):
     """
     Convert polar coordinates in a DataFrame to Cartesian coordinates.
 
-    This function adds Cartesian coordinate columns (`X_<dist_column>` and
-    `Y_<dist_column>`) to the input DataFrame based on polar inputs defined
-    by wind direction (in degrees from North) and radial distance.
+    This function computes Cartesian coordinate columns (`X_<dist_column>` and
+    `Y_<dist_column>`) from polar inputs defined by wind direction (in degrees
+    from North) and one or more radial distance columns. Unlike a mutating
+    helper, it does **not** modify the input DataFrame; it returns only the
+    newly computed coordinate columns.
 
     Parameters
     ----------
@@ -25,16 +27,19 @@ def polar_to_cartesian_dataframe(df, wd_column="WD", dist_column="Dist"):
     wd_column : str, optional
         Name of the column representing wind direction in degrees from North,
         by default "WD".
-    dist_column : str, optional
-        Name of the column representing distance from origin,
-        by default "Dist".
+    dist_column : str or list of str, optional
+        Name(s) of the column(s) representing distance from origin. A single
+        column name produces one ``X_``/``Y_`` pair; a list of names produces
+        a pair for each distance column. By default "Dist".
 
     Returns
     -------
     pandas.DataFrame
-        Modified DataFrame with two new columns:
-        - `'X_<dist_column>'`: Cartesian X coordinate
-        - `'Y_<dist_column>'`: Cartesian Y coordinate
+        A new DataFrame (indexed like ``df``) containing only the computed
+        coordinate columns. For each distance column ``c`` two columns are
+        returned:
+        - `'X_<c>'`: Cartesian X coordinate
+        - `'Y_<c>'`: Cartesian Y coordinate
 
     Notes
     -----
@@ -42,26 +47,34 @@ def polar_to_cartesian_dataframe(df, wd_column="WD", dist_column="Dist"):
     - Wind direction is converted such that 0° = North, 90° = East, etc.
     - Cartesian conversion is performed using:
       `X = dist * cos(θ)` and `Y = dist * sin(θ)` where θ = (90 - WD) in degrees.
+    - The input DataFrame is left unchanged.
     """
-    # Create copies of the input columns to avoid modifying original data
-    wd = df[wd_column].copy()
-    dist = df[dist_column].copy()
+    # Accept either a single column name or a list of column names
+    if isinstance(dist_column, str):
+        dist_columns = [dist_column]
+    else:
+        dist_columns = list(dist_column)
 
-    # Identify invalid values (-9999 or NaN)
-    invalid_mask = (wd == -9999) | (dist == -9999) | wd.isna() | dist.isna()
+    wd = df[wd_column]
 
-    # Convert degrees from north to standard polar angle (radians) where valid
+    # Convert degrees from north to standard polar angle (radians)
     theta_radians = np.radians(90 - wd)
+    cos_theta = np.cos(theta_radians)
+    sin_theta = np.sin(theta_radians)
 
-    # Calculate Cartesian coordinates, setting invalid values to NaN
-    df[f"X_{dist_column}"] = np.where(
-        invalid_mask, np.nan, dist * np.cos(theta_radians)
-    )
-    df[f"Y_{dist_column}"] = np.where(
-        invalid_mask, np.nan, dist * np.sin(theta_radians)
-    )
+    # Build only the new coordinate columns, leaving ``df`` untouched
+    result = {}
+    for col in dist_columns:
+        dist = df[col]
 
-    return df
+        # Identify invalid values (-9999 or NaN) in either input
+        invalid_mask = (wd == -9999) | (dist == -9999) | wd.isna() | dist.isna()
+
+        # Calculate Cartesian coordinates, setting invalid values to NaN
+        result[f"X_{col}"] = np.where(invalid_mask, np.nan, dist * cos_theta)
+        result[f"Y_{col}"] = np.where(invalid_mask, np.nan, dist * sin_theta)
+
+    return pd.DataFrame(result, index=df.index)
 
 
 def aggregate_to_daily_centroid(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -43,6 +43,59 @@ def test_polar_to_cartesian_dataframe_basic():
     assert out["X_Dist"].iloc[4:].isna().all()
     assert out["Y_Dist"].iloc[4:].isna().all()
 
+
+def test_polar_to_cartesian_dataframe_returns_only_new_columns():
+    """The result holds only the new X_/Y_ columns and the input is unchanged."""
+    df = pd.DataFrame({"WD": [0, 90], "Dist": [1, 1]})
+    original_columns = list(df.columns)
+
+    out = polar_to_cartesian_dataframe(df)
+
+    # Only the freshly computed coordinate columns are returned
+    assert list(out.columns) == ["X_Dist", "Y_Dist"]
+
+    # The input DataFrame is left untouched (no in-place mutation)
+    assert list(df.columns) == original_columns
+
+    # Index is preserved
+    assert out.index.equals(df.index)
+
+
+def test_polar_to_cartesian_dataframe_list_of_columns():
+    """A list of distance columns yields an X_/Y_ pair for each."""
+    df = pd.DataFrame(
+        {
+            "WD": [0, 90, 180],
+            "FETCH_90": [1, 1, 1],
+            "FETCH_40": [2, 2, 2],
+        }
+    )
+
+    out = polar_to_cartesian_dataframe(
+        df, dist_column=["FETCH_90", "FETCH_40"]
+    )
+
+    assert list(out.columns) == [
+        "X_FETCH_90",
+        "Y_FETCH_90",
+        "X_FETCH_40",
+        "Y_FETCH_40",
+    ]
+
+    # Spot-check known angles for both distance columns
+    np.testing.assert_allclose(
+        out["X_FETCH_90"], np.array([0, 1, 0], dtype=float), atol=1e-12
+    )
+    np.testing.assert_allclose(
+        out["Y_FETCH_90"], np.array([1, 0, -1], dtype=float), atol=1e-12
+    )
+    np.testing.assert_allclose(
+        out["X_FETCH_40"], np.array([0, 2, 0], dtype=float), atol=1e-12
+    )
+    np.testing.assert_allclose(
+        out["Y_FETCH_40"], np.array([2, 0, -2], dtype=float), atol=1e-12
+    )
+
 # ---------------------------------------------------------------------------
 # generate_density_raster
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses #1, which asks to *"Modify the polar to cartesian to accept list of columns and have it only return columns (series)."*

`polar_to_cartesian_dataframe` previously accepted only a single `dist_column` and mutated the caller's DataFrame in place, returning the whole thing. The codebase routinely works with several distance columns sharing one wind-direction column (e.g. `FETCH_90`, `FETCH_55`, `FETCH_40` in `concat_fetch_gdf`), so this required repeated calls and produced unwanted side effects.

## Changes

`src/fluxfootprints/by_row_fetch_tools.py`:
- `dist_column` now accepts **either a single name or a list of names**, producing an `X_<c>`/`Y_<c>` pair for each.
- Returns a **new DataFrame containing only the computed coordinate columns** (indexed like the input) — the input DataFrame is no longer mutated.
- Updated the docstring accordingly.

`tests/test_tools.py`:
- Added a test confirming the result holds only the new columns and the input is left unchanged.
- Added a test for the list-of-columns path with known-angle spot checks.

## Testing

All three `polar_to_cartesian_dataframe` tests pass. The existing test is unaffected because it only accesses `X_Dist`/`Y_Dist`.

> Note: `test_generate_density_raster_properties` fails on the default branch as well — a pre-existing `gaussian_kde` singular-matrix error from collinear test points — and is outside this issue's scope.

## Compatibility

Backward-compatible for the existing column-access usage. Any caller relying on the old behavior of receiving the *full* mutated DataFrame back would need to adjust, but no such caller exists in the repo.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEWH5sk7RMhGjAkgmPhzFY)_